### PR TITLE
Add dynamic memory file support to Memory MCP Server

### DIFF
--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -1,226 +1,70 @@
-# Knowledge Graph Memory Server
-A basic implementation of persistent memory using a local knowledge graph. This lets Claude remember information about the user across chats.
+# Memory MCP Server with Dynamic Memory File Support
 
-## Core Concepts
+This MCP server provides a knowledge graph memory system for Claude. It enables storing entities, relations, and observations with full dynamic memory file selection.
 
-### Entities
-Entities are the primary nodes in the knowledge graph. Each entity has:
-- A unique name (identifier)
-- An entity type (e.g., "person", "organization", "event")
-- A list of observations
+## Features
 
-Example:
+- Create and manage entities with observations
+- Create relationships between entities
+- Search and retrieve nodes from the knowledge graph
+- **Dynamic memory file selection:** Change the memory file at runtime without restarting the server
+
+## Usage
+
+### Installation
+
+```bash
+npx @modelcontextprotocol/server-memory
+```
+
+### Environment Variables
+
+- `MEMORY_FILE_PATH`: Set the initial path for the memory file (optional, defaults to `memory.json` in the server directory)
+
+### New API Tools
+
+This fork adds new API tools for dynamic memory file management:
+
+#### 1. `set_memory_file`
+Changes the memory file path used for storing the knowledge graph.
+
+**Input:**
 ```json
 {
-  "name": "John_Smith",
-  "entityType": "person",
-  "observations": ["Speaks fluent Spanish"]
+  "path": "path/to/your/memory-file.json" 
 }
 ```
 
-### Relations
-Relations define directed connections between entities. They are always stored in active voice and describe how entities interact or relate to each other.
+The path can be absolute or relative to the server directory.
 
-Example:
-```json
-{
-  "from": "John_Smith",
-  "to": "Anthropic",
-  "relationType": "works_at"
-}
+#### 2. `get_memory_file`
+Returns the current memory file path being used.
+
+#### 3. `health_check` 
+Checks if the server is running and returns the current memory file path.
+
+## Use Cases
+
+This dynamic memory file feature enables:
+
+1. **Multiple memory contexts:** Switch between different knowledge bases
+2. **Backup and restore:** Create snapshots by switching files
+3. **User-specific memories:** Change memory files based on user identity
+4. **Isolation for testing:** Use temporary memory files
+
+## Example
+
+```javascript
+// Get current memory file
+const result = await callTool("get_memory_file");
+console.log(`Current memory file: ${result}`);
+
+// Switch to a different memory file
+await callTool("set_memory_file", { 
+  path: "team-project-memory.json" 
+});
+
+// Verify the change
+const healthCheck = await callTool("health_check");
+console.log(healthCheck);
 ```
-### Observations
-Observations are discrete pieces of information about an entity. They are:
-
-- Stored as strings
-- Attached to specific entities
-- Can be added or removed independently
-- Should be atomic (one fact per observation)
-
-Example:
-```json
-{
-  "entityName": "John_Smith",
-  "observations": [
-    "Speaks fluent Spanish",
-    "Graduated in 2019",
-    "Prefers morning meetings"
-  ]
-}
-```
-
-## API
-
-### Tools
-- **create_entities**
-  - Create multiple new entities in the knowledge graph
-  - Input: `entities` (array of objects)
-    - Each object contains:
-      - `name` (string): Entity identifier
-      - `entityType` (string): Type classification
-      - `observations` (string[]): Associated observations
-  - Ignores entities with existing names
-
-- **create_relations**
-  - Create multiple new relations between entities
-  - Input: `relations` (array of objects)
-    - Each object contains:
-      - `from` (string): Source entity name
-      - `to` (string): Target entity name
-      - `relationType` (string): Relationship type in active voice
-  - Skips duplicate relations
-
-- **add_observations**
-  - Add new observations to existing entities
-  - Input: `observations` (array of objects)
-    - Each object contains:
-      - `entityName` (string): Target entity
-      - `contents` (string[]): New observations to add
-  - Returns added observations per entity
-  - Fails if entity doesn't exist
-
-- **delete_entities**
-  - Remove entities and their relations
-  - Input: `entityNames` (string[])
-  - Cascading deletion of associated relations
-  - Silent operation if entity doesn't exist
-
-- **delete_observations**
-  - Remove specific observations from entities
-  - Input: `deletions` (array of objects)
-    - Each object contains:
-      - `entityName` (string): Target entity
-      - `observations` (string[]): Observations to remove
-  - Silent operation if observation doesn't exist
-
-- **delete_relations**
-  - Remove specific relations from the graph
-  - Input: `relations` (array of objects)
-    - Each object contains:
-      - `from` (string): Source entity name
-      - `to` (string): Target entity name
-      - `relationType` (string): Relationship type
-  - Silent operation if relation doesn't exist
-
-- **read_graph**
-  - Read the entire knowledge graph
-  - No input required
-  - Returns complete graph structure with all entities and relations
-
-- **search_nodes**
-  - Search for nodes based on query
-  - Input: `query` (string)
-  - Searches across:
-    - Entity names
-    - Entity types
-    - Observation content
-  - Returns matching entities and their relations
-
-- **open_nodes**
-  - Retrieve specific nodes by name
-  - Input: `names` (string[])
-  - Returns:
-    - Requested entities
-    - Relations between requested entities
-  - Silently skips non-existent nodes
-
-# Usage with Claude Desktop
-
-### Setup
-
-Add this to your claude_desktop_config.json:
-
-#### Docker
-
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "docker",
-      "args": ["run", "-i", "-v", "claude-memory:/app/dist", "--rm", "mcp/memory"]
-    }
-  }
-}
-```
-
-#### NPX
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-memory"
-      ]
-    }
-  }
-}
-```
-
-#### NPX with custom setting
-
-The server can be configured using the following environment variables:
-
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-memory"
-      ],
-      "env": {
-        "MEMORY_FILE_PATH": "/path/to/custom/memory.json"
-      }
-    }
-  }
-}
-```
-
-- `MEMORY_FILE_PATH`: Path to the memory storage JSON file (default: `memory.json` in the server directory)
-
-### System Prompt
-
-The prompt for utilizing memory depends on the use case. Changing the prompt will help the model determine the frequency and types of memories created.
-
-Here is an example prompt for chat personalization. You could use this prompt in the "Custom Instructions" field of a [Claude.ai Project](https://www.anthropic.com/news/projects). 
-
-```
-Follow these steps for each interaction:
-
-1. User Identification:
-   - You should assume that you are interacting with default_user
-   - If you have not identified default_user, proactively try to do so.
-
-2. Memory Retrieval:
-   - Always begin your chat by saying only "Remembering..." and retrieve all relevant information from your knowledge graph
-   - Always refer to your knowledge graph as your "memory"
-
-3. Memory
-   - While conversing with the user, be attentive to any new information that falls into these categories:
-     a) Basic Identity (age, gender, location, job title, education level, etc.)
-     b) Behaviors (interests, habits, etc.)
-     c) Preferences (communication style, preferred language, etc.)
-     d) Goals (goals, targets, aspirations, etc.)
-     e) Relationships (personal and professional relationships up to 3 degrees of separation)
-
-4. Memory Update:
-   - If any new information was gathered during the interaction, update your memory as follows:
-     a) Create entities for recurring organizations, people, and significant events
-     b) Connect them to the current entities using relations
-     b) Store facts about them as observations
-```
-
-## Building
-
-Docker:
-
-```sh
-docker build -t mcp/memory -f src/memory/Dockerfile . 
-```
-
-## License
-
-This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "@modelcontextprotocol/server-memory",
-  "version": "0.6.3",
-  "description": "MCP server for enabling memory for Claude through a knowledge graph",
+  "name": "@modelcontextprotocol/server-memory-dynamic",
+  "version": "0.7.0",
+  "description": "MCP server for enabling memory for Claude through a knowledge graph with dynamic memory file support",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
+  "contributors": [
+    "Matheus Prol (https://github.com/mhprol)"
+  ],
   "homepage": "https://modelcontextprotocol.io",
-  "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "bugs": "https://github.com/mhprol/servers/issues",
   "type": "module",
   "bin": {
-    "mcp-server-memory": "dist/index.js"
+    "mcp-server-memory-dynamic": "dist/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Dynamic Memory File Feature

This PR adds dynamic memory file support to the Memory MCP Server, allowing switching between different JSON backend files at runtime without restarting the server.

### Changes

1. **KnowledgeGraphManager Class Refactoring**:
   - Now accepts file path in constructor
   - Added methods to get/set memory file path
   - File operations now use instance property instead of global constant

2. **New API Tools**:
   - `set_memory_file`: Changes memory file path
   - `get_memory_file`: Returns current memory file path
   - `health_check`: Validates server status and returns current file path

3. **Documentation**:
   - Added README with feature explanation and examples
   - Updated package info

### Use Cases

- Multiple memory contexts for different projects/users
- Backup and restore functionality
- Testing in isolated environments
- On-demand memory file switching

All existing functionality remains backward compatible.
