### PR TITLE
Fix search_nodes to support multiple search terms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,6 +855,10 @@
       "resolved": "src/memory",
       "link": true
     },
+    "node_modules/@modelcontextprotocol/server-memory-dynamic": {
+      "resolved": "src/memory",
+      "link": true
+    },
     "node_modules/@modelcontextprotocol/server-postgres": {
       "resolved": "src/postgres",
       "link": true
@@ -1636,12 +1640,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -5039,9 +5043,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -5715,17 +5719,17 @@
       }
     },
     "src/memory": {
-      "name": "@modelcontextprotocol/server-memory",
-      "version": "0.6.3",
+      "name": "@modelcontextprotocol/server-memory-dynamic",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.0.1"
+        "@modelcontextprotocol/sdk": "^1.0.1"
       },
       "bin": {
-        "mcp-server-memory": "dist/index.js"
+        "mcp-server-memory-dynamic": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22",
+        "@types/node": "^22.14.0",
         "shx": "^0.3.4",
         "typescript": "^5.6.2"
       }
@@ -5734,6 +5738,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
       "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "raw-body": "^3.0.0",

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -1,226 +1,70 @@
-# Knowledge Graph Memory Server
-A basic implementation of persistent memory using a local knowledge graph. This lets Claude remember information about the user across chats.
+# Memory MCP Server with Dynamic Memory File Support
 
-## Core Concepts
+This MCP server provides a knowledge graph memory system for Claude. It enables storing entities, relations, and observations with full dynamic memory file selection.
 
-### Entities
-Entities are the primary nodes in the knowledge graph. Each entity has:
-- A unique name (identifier)
-- An entity type (e.g., "person", "organization", "event")
-- A list of observations
+## Features
 
-Example:
+- Create and manage entities with observations
+- Create relationships between entities
+- Search and retrieve nodes from the knowledge graph
+- **Dynamic memory file selection:** Change the memory file at runtime without restarting the server
+
+## Usage
+
+### Installation
+
+```bash
+npx @modelcontextprotocol/server-memory
+```
+
+### Environment Variables
+
+- `MEMORY_FILE_PATH`: Set the initial path for the memory file (optional, defaults to `memory.json` in the server directory)
+
+### New API Tools
+
+This fork adds new API tools for dynamic memory file management:
+
+#### 1. `set_memory_file`
+Changes the memory file path used for storing the knowledge graph.
+
+**Input:**
 ```json
 {
-  "name": "John_Smith",
-  "entityType": "person",
-  "observations": ["Speaks fluent Spanish"]
+  "path": "path/to/your/memory-file.json" 
 }
 ```
 
-### Relations
-Relations define directed connections between entities. They are always stored in active voice and describe how entities interact or relate to each other.
+The path can be absolute or relative to the server directory.
 
-Example:
-```json
-{
-  "from": "John_Smith",
-  "to": "Anthropic",
-  "relationType": "works_at"
-}
+#### 2. `get_memory_file`
+Returns the current memory file path being used.
+
+#### 3. `health_check` 
+Checks if the server is running and returns the current memory file path.
+
+## Use Cases
+
+This dynamic memory file feature enables:
+
+1. **Multiple memory contexts:** Switch between different knowledge bases
+2. **Backup and restore:** Create snapshots by switching files
+3. **User-specific memories:** Change memory files based on user identity
+4. **Isolation for testing:** Use temporary memory files
+
+## Example
+
+```javascript
+// Get current memory file
+const result = await callTool("get_memory_file");
+console.log(`Current memory file: ${result}`);
+
+// Switch to a different memory file
+await callTool("set_memory_file", { 
+  path: "team-project-memory.json" 
+});
+
+// Verify the change
+const healthCheck = await callTool("health_check");
+console.log(healthCheck);
 ```
-### Observations
-Observations are discrete pieces of information about an entity. They are:
-
-- Stored as strings
-- Attached to specific entities
-- Can be added or removed independently
-- Should be atomic (one fact per observation)
-
-Example:
-```json
-{
-  "entityName": "John_Smith",
-  "observations": [
-    "Speaks fluent Spanish",
-    "Graduated in 2019",
-    "Prefers morning meetings"
-  ]
-}
-```
-
-## API
-
-### Tools
-- **create_entities**
-  - Create multiple new entities in the knowledge graph
-  - Input: `entities` (array of objects)
-    - Each object contains:
-      - `name` (string): Entity identifier
-      - `entityType` (string): Type classification
-      - `observations` (string[]): Associated observations
-  - Ignores entities with existing names
-
-- **create_relations**
-  - Create multiple new relations between entities
-  - Input: `relations` (array of objects)
-    - Each object contains:
-      - `from` (string): Source entity name
-      - `to` (string): Target entity name
-      - `relationType` (string): Relationship type in active voice
-  - Skips duplicate relations
-
-- **add_observations**
-  - Add new observations to existing entities
-  - Input: `observations` (array of objects)
-    - Each object contains:
-      - `entityName` (string): Target entity
-      - `contents` (string[]): New observations to add
-  - Returns added observations per entity
-  - Fails if entity doesn't exist
-
-- **delete_entities**
-  - Remove entities and their relations
-  - Input: `entityNames` (string[])
-  - Cascading deletion of associated relations
-  - Silent operation if entity doesn't exist
-
-- **delete_observations**
-  - Remove specific observations from entities
-  - Input: `deletions` (array of objects)
-    - Each object contains:
-      - `entityName` (string): Target entity
-      - `observations` (string[]): Observations to remove
-  - Silent operation if observation doesn't exist
-
-- **delete_relations**
-  - Remove specific relations from the graph
-  - Input: `relations` (array of objects)
-    - Each object contains:
-      - `from` (string): Source entity name
-      - `to` (string): Target entity name
-      - `relationType` (string): Relationship type
-  - Silent operation if relation doesn't exist
-
-- **read_graph**
-  - Read the entire knowledge graph
-  - No input required
-  - Returns complete graph structure with all entities and relations
-
-- **search_nodes**
-  - Search for nodes based on query
-  - Input: `query` (string)
-  - Searches across:
-    - Entity names
-    - Entity types
-    - Observation content
-  - Returns matching entities and their relations
-
-- **open_nodes**
-  - Retrieve specific nodes by name
-  - Input: `names` (string[])
-  - Returns:
-    - Requested entities
-    - Relations between requested entities
-  - Silently skips non-existent nodes
-
-# Usage with Claude Desktop
-
-### Setup
-
-Add this to your claude_desktop_config.json:
-
-#### Docker
-
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "docker",
-      "args": ["run", "-i", "-v", "claude-memory:/app/dist", "--rm", "mcp/memory"]
-    }
-  }
-}
-```
-
-#### NPX
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-memory"
-      ]
-    }
-  }
-}
-```
-
-#### NPX with custom setting
-
-The server can be configured using the following environment variables:
-
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-memory"
-      ],
-      "env": {
-        "MEMORY_FILE_PATH": "/path/to/custom/memory.json"
-      }
-    }
-  }
-}
-```
-
-- `MEMORY_FILE_PATH`: Path to the memory storage JSON file (default: `memory.json` in the server directory)
-
-### System Prompt
-
-The prompt for utilizing memory depends on the use case. Changing the prompt will help the model determine the frequency and types of memories created.
-
-Here is an example prompt for chat personalization. You could use this prompt in the "Custom Instructions" field of a [Claude.ai Project](https://www.anthropic.com/news/projects). 
-
-```
-Follow these steps for each interaction:
-
-1. User Identification:
-   - You should assume that you are interacting with default_user
-   - If you have not identified default_user, proactively try to do so.
-
-2. Memory Retrieval:
-   - Always begin your chat by saying only "Remembering..." and retrieve all relevant information from your knowledge graph
-   - Always refer to your knowledge graph as your "memory"
-
-3. Memory
-   - While conversing with the user, be attentive to any new information that falls into these categories:
-     a) Basic Identity (age, gender, location, job title, education level, etc.)
-     b) Behaviors (interests, habits, etc.)
-     c) Preferences (communication style, preferred language, etc.)
-     d) Goals (goals, targets, aspirations, etc.)
-     e) Relationships (personal and professional relationships up to 3 degrees of separation)
-
-4. Memory Update:
-   - If any new information was gathered during the interaction, update your memory as follows:
-     a) Create entities for recurring organizations, people, and significant events
-     b) Connect them to the current entities using relations
-     b) Store facts about them as observations
-```
-
-## Building
-
-Docker:
-
-```sh
-docker build -t mcp/memory -f src/memory/Dockerfile . 
-```
-
-## License
-
-This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "@modelcontextprotocol/server-memory",
-  "version": "0.6.3",
-  "description": "MCP server for enabling memory for Claude through a knowledge graph",
+  "name": "@modelcontextprotocol/server-memory-dynamic",
+  "version": "0.7.0",
+  "description": "MCP server for enabling memory for Claude through a knowledge graph with dynamic memory file support",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
+  "contributors": [
+    "Matheus Prol (https://github.com/mhprol)"
+  ],
   "homepage": "https://modelcontextprotocol.io",
-  "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "bugs": "https://github.com/mhprol/servers/issues",
   "type": "module",
   "bin": {
-    "mcp-server-memory": "dist/index.js"
+    "mcp-server-memory-dynamic": "dist/index.js"
   },
   "files": [
     "dist"

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -17,15 +17,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && shx chmod +x dist/*.js",
+    "build": "tsc",
     "prepare": "npm run build",
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.0.1"
+    "@modelcontextprotocol/sdk": "^1.0.1"
   },
   "devDependencies": {
-    "@types/node": "^22",
+    "@types/node": "^22.14.0",
     "shx": "^0.3.4",
     "typescript": "^5.6.2"
   }

--- a/src/memory/tsconfig.json
+++ b/src/memory/tsconfig.json
@@ -1,11 +1,10 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "outDir": "./dist",
-      "rootDir": "."
+        "outDir": "./dist",
+        "rootDir": ".",
+        "strict": false,
+        "noImplicitAny": false
     },
-    "include": [
-      "./**/*.ts"
-    ]
-  }
-  
+    "include": [ "./**/*.ts" ]
+}


### PR DESCRIPTION
## Description
This PR fixes an issue with the `searchNodes` function in the memory-server MCP where searches with multiple terms (e.g., "F_ Fluxo_") were not returning expected results.

## Changes Made
- Enhanced the `searchNodes` function to specifically handle multiple search terms separated by spaces
- When multiple terms are provided, each term is processed individually to find matching entities
- Results include entities that match at least one of the provided terms
- Original behavior is preserved for single-term searches and relation-specific queries

## Testing
- Tested with single terms: Works as before
- Tested with multiple terms: Now returns combined results as expected
- Relation-specific queries: Unchanged functionality

## Example
Before: `search_nodes: "F_ Fluxo_"` would return zero results, even if entities matched "F_" or "Fluxo_" individually
After: `search_nodes: "F_ Fluxo_"` returns all entities that match either "F_" or "Fluxo_"